### PR TITLE
Make ocetrac lazy

### DIFF
--- a/ocetrac/model.py
+++ b/ocetrac/model.py
@@ -4,6 +4,7 @@ import scipy.ndimage
 from skimage.measure import regionprops 
 from skimage.measure import label as label_np
 import dask.array as dsa
+from xarray.tests import raise_if_dask_computes
 
 
 class Tracker:
@@ -61,7 +62,10 @@ class Tracker:
 
         # Apply mask
         binary_images_with_mask  = self._apply_mask(binary_images,self.mask) # perhaps change to method? JB
-
+    
+        if (binary_images_with_mask == 0).all():
+            raise ValueError('No features found in `da` input. Try adjusting `radius` and `min_size_quartile`')
+        
         # Filter area
         area, min_area, binary_labels, N_initial = self._filter_area(binary_images_with_mask)
 
@@ -162,7 +166,7 @@ class Tracker:
                                 output_dtypes=[binary_images.dtype],
                                 vectorize=True,
                                 dask='parallelized')
-        print(labels)
+
         labels = labels.where(labels>0, drop=False, other=np.nan)  
 
         # The labels are repeated each time step, therefore we relabel them to be consecutive

--- a/ocetrac/model.py
+++ b/ocetrac/model.py
@@ -4,7 +4,6 @@ import scipy.ndimage
 from skimage.measure import regionprops 
 from skimage.measure import label as label_np
 import dask.array as dsa
-from xarray.tests import raise_if_dask_computes
 
 
 class Tracker:

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -37,8 +37,8 @@ def example_data():
 
 @pytest.mark.parametrize("radius", [2, 4])
 @pytest.mark.parametrize("min_size_quartile", [0.75, 0.80])
-@pytest.mark.parametrize('xdim', ['lon', 'longitude', 'whoo'])
-@pytest.mark.parametrize('ydim', ['lat', 'latitude', 'whaa'])
+@pytest.mark.parametrize('xdim', ['x', 'lon', 'longitude'])
+@pytest.mark.parametrize('ydim', ['y', 'lat', 'latitude'])
 @pytest.mark.parametrize('dask', [True, False])
 def test_track(example_data, radius, min_size_quartile, xdim, ydim, dask):
     


### PR DESCRIPTION
This PR is a WIP towards #14 

It includes:
- [x] Small refactor of _apply_mask (reverting that to a class method)
- [x] A new test `test_track_dask_lazy` that compares the output for dask/numpy input and raises an error each time it detects a non-lazy operation when calling `Tracker.track()`. 
- I still need to go through each step in order to make it lazy. 

@hscannel as I mentioned earlier, I am a bit unsure if these edits to the logic are changing the output. If you have an idea for an even more idealized dataset, for which we could manually generate the output we want (as a rock solid ground truth), that would give me a lot more confidence in making changes.