### PR TITLE
Fix `np.nan` maxlabel when no events found

### DIFF
--- a/ocetrac/tracker.py
+++ b/ocetrac/tracker.py
@@ -186,17 +186,18 @@ class Tracker:
                                 vectorize=True,
                                 dask='parallelized')
 
-
         labels = xr.DataArray(labels, dims=binary_images.dims, coords=binary_images.coords)
-        labels = labels.where(labels>0, drop=False, other=np.nan)  
-
+        labels = labels.where(labels>0, drop=False, other=np.nan)
+        
         # The labels are repeated each time step, therefore we relabel them to be consecutive
         for i in range(1, labels.shape[0]):
-            labels[i,:,:] = labels[i,:,:].values + labels[i-1,:,:].max().values
+            max_label = np.nanmax(labels[i-1,:,:])
+            max_label = 0. if np.isnan(max_label) else max_label
+            labels[i,:,:] = labels[i,:,:].values + max_label
 
         labels = labels.where(labels>0, drop=False, other=0)  
         labels_wrapped, N_initial = self._wrap(np.array(labels))
-
+        
         # Calculate Area of each object and keep objects larger than threshold
         props = regionprops(labels_wrapped.astype('int'))
         

--- a/ocetrac/tracker.py
+++ b/ocetrac/tracker.py
@@ -191,8 +191,8 @@ class Tracker:
         
         # The labels are repeated each time step, therefore we relabel them to be consecutive
         for i in range(1, labels.shape[0]):
-            max_label = np.nanmax(labels[i-1,:,:])
-            max_label = 0. if np.isnan(max_label) else max_label
+            max_label = labels[i-1,:,:].max().values
+            max_label = 0 if np.isnan(max_label) else max_label
             labels[i,:,:] = labels[i,:,:].values + max_label
 
         labels = labels.where(labels>0, drop=False, other=0)  


### PR DESCRIPTION
Fix bug whereby NaNs propagate through labels when no events are found in a given iteration.

In the `_filter_area` method, there is a line that adds the maximum label in
the previous timestep to the labels of the current timestep, so that all
of the labels become unique. In the edge case where there is no labelled
event present in the previous iteration, `labels[i-1,:,:]`, however, this
operation `labels[i-1,:,;].max().values` would return `np.nan`, which then
corrupts valid (integer) label values in the current iteration. This then
propagates through to the remainder of the dataset.

This bug is fixed by simply adding a line that sets the `max_label` to the previous valid value of `max_label` if it is a `np.nan` type.

Presumably this had been missed because ocetrac was only tested on global datasets, where at least one event is present at any given time. This is not the case the problem that @marianatorres4 is working on, where events dissappear from the entire domain in winter.